### PR TITLE
Add a GitHub Workflow to automatically build the engine

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,14 @@
-name: SoF2Plus Build
+name: SoF2Plus Latest Build
 
 on:
   push:
-    branches: [ master, autobuild ]
+    branches: [ master ]
   pull_request:
-    branches: [ master, autobuild ]
+    branches: [ master ]
   workflow_dispatch:
+
+permissions:
+  contents: write
 
 jobs:
   build:
@@ -220,10 +223,54 @@ jobs:
         with:
           name: "sof2plus-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.compiler }}"
           path: "*.tar.gz"
-
+          
       - name: Upload Artifact (.zip)
         if: matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
           name: "sof2plus-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.compiler }}"
           path: "*.zip"
+
+  # ==================================================================
+  # Create or Update "Latest" Release (only once per workflow run)
+  # ==================================================================
+  release:
+    needs: build
+    if: github.ref == 'refs/heads/master'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: release_artifacts
+
+      - name: Prepare release tag
+        run: |
+          DATE=$(date -u +"%Y-%m-%d")
+          echo "RELEASE_DATE=$DATE" >> $GITHUB_ENV
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+
+          # Delete old Latest tag if exists
+          git tag -d Latest || true
+          git push origin :refs/tags/Latest || true
+
+          # Recreate Latest tag at current commit
+          git tag -a Latest -m "Latest automated build ($DATE)"
+          git push origin Latest
+
+      - name: Create GitHub Release (Latest)
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: Latest
+          name: "Latest Build — ${{ env.DATE }}"
+          body: |
+            This release contains all the latest builds for each platform and configuration.
+            Updated automatically from **master**.
+          files: |
+            release_artifacts/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,229 @@
+name: SoF2Plus Build
+
+on:
+  push:
+    branches: [ master, autobuild ]
+  pull_request:
+    branches: [ master, autobuild ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        arch: [x86, x86_64]
+        build_type: [Debug, Release]
+        compiler: [gcc, mingw, msvc]
+        exclude:
+          - os: ubuntu-latest
+            compiler: mingw
+          - os: ubuntu-latest
+            compiler: msvc
+          - os: windows-latest
+            compiler: gcc
+
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set Env Vars
+        id: env
+        run: |
+          echo "BUILD_TYPE_LOWER=${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}" >> $GITHUB_ENV
+          echo "BUILD_DIR=build/$BUILD_TYPE_LOWER-${{ matrix.compiler }}-${{ matrix.arch }}" >> $GITHUB_ENV
+          echo "BIN_NAME=sof2plus.${{ matrix.arch }}${{ matrix.os == 'windows-latest' && '.exe' || '' }}" >> $GITHUB_ENV
+
+      # ==================================================================
+      # MSVC Build
+      # ==================================================================
+      - name: Setup MSBuild
+        if: matrix.compiler == 'msvc'
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Build MSVC
+        if: matrix.compiler == 'msvc'
+        shell: pwsh
+        run: |
+          msbuild misc/msvc14/sof2plus-engine.sln /p:Configuration='${{ matrix.build_type }}' /p:Platform='${{ matrix.arch == 'x86_64' && 'x64' || 'Win32' }}' /m
+
+      # ==================================================================
+      # MinGW via MSYS2
+      # ==================================================================
+      - name: Setup MSYS2
+        if: matrix.compiler == 'mingw'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: ${{ matrix.arch == 'x86_64' && 'MINGW64' || 'MINGW32' }}
+          update: true
+          install: >-
+            base
+            git
+            make
+            ${{ matrix.arch == 'x86_64' && 'mingw-w64-x86_64' || 'mingw-w64-i686' }}-toolchain 
+            ${{ matrix.arch == 'x86_64' && 'mingw-w64-x86_64' || 'mingw-w64-i686' }}-cmake 
+            ${{ matrix.arch == 'x86_64' && 'mingw-w64-x86_64' || 'mingw-w64-i686' }}-ninja 
+            ${{ matrix.arch == 'x86_64' && 'mingw-w64-x86_64' || 'mingw-w64-i686' }}-libwinpthread 
+
+      - name: Install libbacktrace (MinGW Debug only)
+        if: matrix.compiler == 'mingw' && matrix.build_type == 'Debug'
+        shell: msys2 {0}
+        run: |
+          export MINGW_PREFIX="/${{ matrix.arch == 'x86_64' && 'mingw64' || 'mingw32' }}"
+          export PATH="$MINGW_PREFIX/bin:$PATH"
+          if ! [ -f "$MINGW_PREFIX/lib/libbacktrace.a" ]; then
+            git clone https://github.com/ianlancetaylor/libbacktrace.git
+            cd libbacktrace
+            ./configure --prefix=$MINGW_PREFIX --enable-static --disable-shared
+            make -j$(nproc)
+            make install
+            rm -f $MINGW_PREFIX/bin/libbacktrace.dll
+            rm -f $MINGW_PREFIX/lib/libbacktrace.dll.a
+          fi
+          ls -la $MINGW_PREFIX/lib/libbacktrace.a
+          ls -la $MINGW_PREFIX/bin/libbacktrace* 2>/dev/null || echo "No DLL"
+      - name: Build MinGW
+        if: matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: |
+          export PATH="/${{ matrix.arch == 'x86_64' && 'mingw64' || 'mingw32' }}/bin:$PATH"
+          mkdir -p $BUILD_DIR
+          cd $BUILD_DIR
+          EXTRA=""
+          if [[ "${{ matrix.arch }}" == "x86" ]]; then
+            EXTRA="-DFORCE_32BIT=On -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_EXE_LINKER_FLAGS=-m32"
+          fi
+          cmake ../../ -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} $EXTRA $STATIC_FLAGS
+          cmake --build . --parallel
+
+      # ==================================================================
+      # Linux
+      # ==================================================================
+      - name: Install Linux deps
+        if: matrix.compiler == 'gcc'
+        run: sudo apt-get update -qq && sudo apt-get install -y build-essential cmake ninja-build libsdl2-dev libjpeg-dev libpng-dev zlib1g-dev gcc-multilib g++-multilib libcurl4-openssl-dev
+
+      - name: Build libbacktrace (Linux Debug only)
+        if: matrix.compiler == 'gcc' && matrix.build_type == 'Debug'
+        run: |
+          if ! dpkg -l | grep libbacktrace; then
+            git clone https://github.com/ianlancetaylor/libbacktrace.git
+            cd libbacktrace
+            ./configure --prefix=/usr --enable-static --disable-shared
+            make -j$(nproc)
+            sudo make install
+          fi
+
+      - name: Build Linux
+        if: matrix.compiler == 'gcc'
+        run: |
+          mkdir -p $BUILD_DIR
+          cd $BUILD_DIR
+          EXTRA=""
+          if [[ "${{ matrix.arch }}" == "x86" ]]; then
+            EXTRA="-DFORCE_32BIT=On -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_EXE_LINKER_FLAGS=-m32"
+          fi
+          cmake ../../ -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} $EXTRA
+          cmake --build . --parallel
+
+      # ==================================================================
+      # Artifacts (Binary + PDB) - MSVC
+      # ==================================================================
+      - name: Collect Artifacts (MSVC)
+        if: always() && matrix.compiler == 'msvc'
+        shell: pwsh
+        run: |
+          mkdir -p artifacts
+          $MSVC_DIR = "build/${{ matrix.build_type == 'Debug' && 'debug' || 'release' }}-msvc14-${{ matrix.arch }}"
+          Copy-Item "$MSVC_DIR/sof2plus.${{ matrix.arch }}.exe" artifacts/
+          if ('${{ matrix.build_type }}' -eq 'Debug') {
+            Copy-Item "$MSVC_DIR/sof2plus.${{ matrix.arch }}.pdb" artifacts/
+            Copy-Item "$MSVC_DIR/sof2plus.${{ matrix.arch }}.ilk" artifacts/ -ErrorAction SilentlyContinue
+          }
+          Write-Host "Collected:"
+          Get-ChildItem artifacts/ | Format-Table -AutoSize
+
+      # ==================================================================
+      # Artifacts (Binary + PDB + DLLs) - MinGW
+      # ==================================================================
+      - name: Collect Artifacts (MinGW)
+        if: always() && matrix.compiler == 'mingw'
+        shell: msys2 {0}
+        run: |
+          mkdir -p artifacts
+
+          SUBDIR=$([[ "${{ matrix.build_type }}" == "Debug" ]] && echo "Debug" || echo "Release")
+          cp "$BUILD_DIR/$SUBDIR/$BIN_NAME" artifacts/
+          # =========================================================
+          # Ship libwinpthread-1.dll for MinGW Debug - needed for x86 build
+          # =========================================================
+          if [[ "${{ matrix.build_type }}" == "Debug" && "${{ matrix.arch }}" == "x86" ]]; then
+            MINGW_ROOT="/mingw32"
+            PTHREAD_DLL="$MINGW_ROOT/bin/libwinpthread-1.dll"
+            if [[ -f "$PTHREAD_DLL" ]]; then
+              cp "$PTHREAD_DLL" artifacts/
+              echo "Copied: $PTHREAD_DLL"
+            else
+              echo "Missing: $PTHREAD_DLL — listing bin/ for debug:"
+              ls -la "$MINGW_ROOT/bin/libwinpt*" || echo "No match"
+              # exit 1
+            fi
+          fi
+
+          echo "Collected:"
+          ls -la artifacts/
+
+      # ==================================================================
+      # Artifacts (Binary) - GCC
+      # ==================================================================
+      - name: Collect Artifacts (GCC)
+        if: always() && matrix.compiler == 'gcc'
+        shell: bash
+        run: |
+          mkdir -p artifacts
+
+          SUBDIR=$([[ "${{ matrix.build_type }}" == "Debug" ]] && echo "Debug" || echo "Release")
+          cp "$BUILD_DIR/$SUBDIR/$BIN_NAME" artifacts/
+          # No libs needed for Linux - dynamic linking
+
+          echo "Collected:"
+          ls -la artifacts/
+
+      - name: Archive Artifacts
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd artifacts
+          tar -czf "../sof2plus-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.compiler }}.tar.gz" *
+          echo "Created tar.gz"
+
+      - name: Archive Artifacts (Windows)
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Set-Location artifacts
+          $name = "sof2plus-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.compiler }}.zip"
+          Compress-Archive -Path * -DestinationPath "../$name" -Force
+          Write-Host "Created $name"
+
+      - name: Upload Artifact (.tar.gz)
+        if: matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: "sof2plus-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.compiler }}"
+          path: "*.tar.gz"
+
+      - name: Upload Artifact (.zip)
+        if: matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: "sof2plus-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.build_type }}-${{ matrix.compiler }}"
+          path: "*.zip"

--- a/cmake/compilers/msvc.cmake
+++ b/cmake/compilers/msvc.cmake
@@ -20,6 +20,10 @@ if(ARCH MATCHES "x86_64")
         PROPERTIES COMPILE_DEFINITIONS "idx64")
 endif()
 
+list(APPEND COMMON_LIBRARIES
+    $<$<CONFIG:Debug>:dbghelp> # MSVC backtrace support. Only in Debug builds
+)
+
 # Baseline warnings
 add_compile_options("$<$<COMPILE_LANGUAGE:C>:/W4>")
 

--- a/cmake/platforms/windows.cmake
+++ b/cmake/platforms/windows.cmake
@@ -14,11 +14,13 @@ list(APPEND COMMON_LIBRARIES
     ws2_32 # Windows Sockets 2
     winmm  # timeBeginPeriod/timeEndPeriod
     psapi  # EnumProcesses
-    $<$<CONFIG:Debug>:dbghelp> # Backtrace support. Only in Debug builds
 )
 
 if(MINGW)
-    list(APPEND COMMON_LIBRARIES mingw32)
+    list(APPEND COMMON_LIBRARIES
+        mingw32
+        $<$<CONFIG:Debug>:backtrace> # MinGW will rely on libbacktrace for backtrace support
+    )
 endif()
 
 list(APPEND CLIENT_DEFINITIONS USE_ICON)

--- a/code/botlib/l_precomp.c
+++ b/code/botlib/l_precomp.c
@@ -753,7 +753,7 @@ int PC_ExpandBuiltinDefine(source_t *source, token_t *deftoken, define_t *define
         case BUILTIN_DATE:
         {
             t = time(NULL);
-            curtime = ctime((const long *)&t);
+            curtime = ctime((const time_t *)&t);
             strcpy(token->string, "\"");
             strncat(token->string, curtime+4, 7);
             strncat(token->string+7, curtime+20, 4);
@@ -768,7 +768,7 @@ int PC_ExpandBuiltinDefine(source_t *source, token_t *deftoken, define_t *define
         case BUILTIN_TIME:
         {
             t = time(NULL);
-            curtime = ctime((const long *)&t);
+            curtime = ctime((const time_t*)&t);
             strcpy(token->string, "\"");
             strncat(token->string, curtime+11, 8);
             strcat(token->string, "\"");

--- a/misc/msvc14/sof2plus-engine.sln
+++ b/misc/msvc14/sof2plus-engine.sln
@@ -8,19 +8,19 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
+		Debug|Win32 = Debug|Win32
 		Release|x64 = Release|x64
-		Release|x86 = Release|x86
+		Release|Win32 = Release|Win32
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Debug|x64.ActiveCfg = Debug|x64
 		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Debug|x64.Build.0 = Debug|x64
-		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Debug|x86.ActiveCfg = Debug|Win32
-		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Debug|x86.Build.0 = Debug|Win32
+		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Debug|Win32.ActiveCfg = Debug|Win32
+		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Debug|Win32.Build.0 = Debug|Win32
 		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Release|x64.ActiveCfg = Release|x64
 		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Release|x64.Build.0 = Release|x64
-		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Release|x86.ActiveCfg = Release|Win32
-		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Release|x86.Build.0 = Release|Win32
+		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Release|Win32.ActiveCfg = Release|Win32
+		{1FD3BB9B-DC72-407D-A8E4-D0216E62708E}.Release|Win32.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/misc/msvc14/sof2plus-engine.vcxproj
+++ b/misc/msvc14/sof2plus-engine.vcxproj
@@ -75,7 +75,7 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>..\..\..\..\..\..\..\Games\sof2plus</OutDir>
+    <OutDir>..\..\build\debug-msvc14-x86</OutDir>
     <IntDir>..\..\build\debug-msvc14-x86\ded\</IntDir>
     <TargetName>sof2plus.x86</TargetName>
     <GenerateManifest>false</GenerateManifest>
@@ -83,20 +83,20 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
     <GenerateManifest>false</GenerateManifest>
-    <OutDir>..\..\..\..\..\..\..\Games\sof2plus</OutDir>
+    <OutDir>..\..\build\debug-msvc14-x86_64</OutDir>
     <IntDir>..\..\build\debug-msvc14-x86_64\ded\</IntDir>
     <TargetName>sof2plus.x86_64</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>..\..\build\release-msvc14-x86\</OutDir>
+    <OutDir>..\..\build\release-msvc14-x86</OutDir>
     <IntDir>..\..\build\release-msvc14-x86\ded\</IntDir>
     <TargetName>sof2plus.x86</TargetName>
     <GenerateManifest>false</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>..\..\build\release-msvc14-x86_64\</OutDir>
+    <OutDir>..\..\build\release-msvc14-x86_64</OutDir>
     <IntDir>..\..\build\release-msvc14-x86_64\ded\</IntDir>
     <TargetName>sof2plus.x86_64</TargetName>
     <GenerateManifest>false</GenerateManifest>
@@ -447,10 +447,10 @@
   <ItemGroup>
     <CustomBuild Include="..\..\code\asm\vm_x86_64.asm">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">ml64 /Didx64 /c /Zi /Fo"$(IntDir)%(Filename).asm.obj" "%(FullPath)"
+      <Command Condition="'$(Platform)'=='x64'">ml64 /Didx64 /c /Zi /Fo"$(IntDir)%(Filename).asm.obj" "%(FullPath)"
 </Command>
-      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Assembling...</Message>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(IntDir)%(Filename).asm.obj;%(Outputs)</Outputs>
+      <Message Condition="'$(Platform)'=='x64'">Assembling...</Message>
+      <Outputs Condition="'$(Platform)'=='x64'">$(IntDir)%(Filename).asm.obj;%(Outputs)</Outputs>
     </CustomBuild>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />


### PR DESCRIPTION
Changes also done to automatically create MinGW builds for Windows (with libbacktrace), VEH for x86 crashdumps on MSVC, renaming x86 to Win32 on MSVC project files.